### PR TITLE
fix: update layouts to add hugo.IsMultilingual

### DIFF
--- a/layouts/partials/language-selector.html
+++ b/layouts/partials/language-selector.html
@@ -1,11 +1,13 @@
-<div class="lang-dropdown">
-  <select class="lang-select" onchange="location = this.value;">
-    {{ $currentLang := .Site.Language.Lang }}
-    {{ $siteBase := strings.TrimSuffix "/" .Site.BaseURL }}
-    {{ range .Site.Languages }}
-    <option value="{{ $siteBase }}/{{ .Lang }}/" {{ if eq .Lang $currentLang }}selected{{ end }}>
-      {{ .LanguageName }}
-    </option>
-    {{ end }}
-  </select>
-</div>
+{{ if hugo.IsMultilingual }}
+  <div class="lang-dropdown">
+    <select class="lang-select" onchange="location = this.value;">
+      {{ $currentLang := .Site.Language.Lang }}
+      {{ $siteBase := strings.TrimSuffix "/" .Site.BaseURL }}
+      {{ range .Site.Languages }}
+        <option value="{{ $siteBase }}/{{ .Lang }}/" {{ if eq .Lang $currentLang }}selected{{ end }}>
+          {{ .LanguageName }}
+        </option>
+      {{ end }}
+    </select>
+  </div>
+{{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -34,12 +34,15 @@
         </li>
         <!-- .nav-item -->
       {{ end }}
-      <li class="nav-item mt-4">
-        <a class="nav-link no-hover">
-          <i class="fa-fw fas fa-language"></i>
-          {{ partial "language-selector.html" . }}
-        </a>
-      </li>
+
+      {{ if hugo.IsMultilingual }}
+        <li class="nav-item mt-4">
+          <a class="nav-link no-hover">
+            <i class="fa-fw fas fa-language"></i>
+            {{ partial "language-selector.html" . }}
+          </a>
+        </li>
+      {{ end }}
     </ul>
   </nav>
 
@@ -57,7 +60,7 @@
     {{ range .Site.Params.social.links }}
       {{ $url := "" }}
       {{ $rel := "" }}
-      
+
       {{ if eq .type "github" }}
         {{ $url = printf "https://github.com/%s" .id }}
       {{ else if eq .type "twitter" }}


### PR DESCRIPTION
Thanks for converting this to Hugo. I came across an issue when using the starter package and trying to remove multilanguage, the menu on the side bar kept displaying.

I found that the hugo.IsMultilingual was not present in the language-selector.html and sidebar.html, so hugo.IsMultilingual was always set to true.

I update the files to include the changes so it hides the dropdown menu and icon correctly.

- Update layouts/partials/language-selector.html to add hugo.IsMultilingual for multilanguage support to hide drop down menu
- Update layours/partials/sidebar.html to add hugo.IsMultilingual to hide language icon.