### PR TITLE
feat: add custom social links

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -57,7 +57,7 @@
     {{ range .Site.Params.social.links }}
       {{ $url := "" }}
       {{ $rel := "" }}
-      
+
       {{ if eq .type "github" }}
         {{ $url = printf "https://github.com/%s" .id }}
       {{ else if eq .type "twitter" }}
@@ -66,6 +66,8 @@
         {{ $url = printf "mailto:%s" .id }}
       {{ else if eq .type "rss" }}
         {{ $url = "index.xml" | absLangURL }}
+      {{ else if eq .type "custom" }}
+        {{ $url = printf "%s" .id }}
       {{ else }}
         {{ $url = .url }}
       {{ end }}


### PR DESCRIPTION
- add custom type for social.links. User can set type = custom with id as a custom URL.

```
[[social.links]] 
  type = "custom" 
  id = "https://example.com/" 
  icon = "fab fa-github"
```

Allows the user to set a custom social.links in the params.toml file with any url or icon of users choosing.

