### PR TITLE
Generate safe plain-text post descriptions

### DIFF
--- a/layouts/_default/index.json
+++ b/layouts/_default/index.json
@@ -1,5 +1,5 @@
 {{- $.Scratch.Add "index" slice -}}
 {{- range .Site.RegularPages -}}
-    {{- $.Scratch.Add "index" (dict "title" .Title "tags" .Params.tags "categories" .Params.categories "contents" .Plain "permalink" .Permalink) -}}
+    {{- $.Scratch.Add "index" (dict "title" .Title "tags" .Params.tags "categories" .Params.categories "contents" (.Plain | htmlUnescape) "permalink" .Permalink) -}}
 {{- end -}}
 {{- $.Scratch.Get "index" | jsonify -}}

--- a/layouts/partials/post-description.html
+++ b/layouts/partials/post-description.html
@@ -3,19 +3,11 @@
 
 {{- $description := "" -}}
 {{- if .Description -}}
-  {{- $description = .Description -}}
+  {{- $description = .Description | plainify | htmlUnescape -}}
 {{- else if .Params.description -}}
-  {{- $description = .Params.description -}}
+  {{- $description = .Params.description | plainify | htmlUnescape -}}
 {{- else -}}
-  {{- /* Remove the line number of the code snippet */ -}}
-  {{- $content := .Content -}}
-
-  {{- if findRE `<td class="rouge-gutter gl"><pre class="lineno">` $content -}}
-    {{- $content = replace $content `<td class="rouge-gutter gl"><pre class="lineno">` `<!-- <td class="rouge-gutter gl"><pre class="lineno">` -}}
-    {{- $content = replace $content `</td><td class="rouge-code">` `</td> --><td class="rouge-code">` -}}
-  {{- end -}}
-
-  {{- $description = $content | markdownify | plainify | replaceRE `\s+` ` ` -}}
+  {{- $description = .Summary | plainify | htmlUnescape | replaceRE `\s+` ` ` -}}
 {{- end -}}
 
-{{- (trim $description " ") | truncate $max_length | safeHTML -}}
+{{- (trim $description " ") | truncate $max_length -}}


### PR DESCRIPTION
## What changed

- Generate fallback post descriptions from Hugo's `Summary` instead of processing rendered content with Jekyll/Rouge-specific markup rules.
- Normalize explicit descriptions and summaries to plain text with decoded HTML entities.
- Keep the final description in the normal escaping pipeline instead of marking content as trusted HTML.
- Decode entities in the generated search index before JSON encoding.

## Why

The existing description partial contains Rouge-specific table handling inherited from the Jekyll theme even though this project renders code with Hugo. It can also leave entities double-escaped. Decoding entities and then passing them to `safeHTML`, however, would allow encoded markup from content to become trusted HTML, so the final value must remain an ordinary escaped string.

## Impact

Related-post descriptions and search content are emitted as readable plain text. Explicit descriptions and automatic summaries cannot inject decoded markup into the generated page.

## Validation

- Hugo 0.164.0 focused fixture with `--panicOnWarning`
- Explicit-description and automatic-summary cases
- Encoded script markup remained escaped in both cases
- Zero raw `<script>` elements in generated output
